### PR TITLE
Add dynamic weights cache sizing

### DIFF
--- a/personal server start scripts/README.md
+++ b/personal server start scripts/README.md
@@ -111,7 +111,7 @@ Example configuration:
 # Enable model browser (allows clients to browse available models)
 MODEL_BROWSER=true
 
-# Set weights cache for better performance (4GB)
+# Set weights cache for better performance (defaults to 50% of RAM if unset)
 WEIGHTS_CACHE=4
 
 # Enable supervised mode (auto-restart on crashes)
@@ -131,7 +131,7 @@ SHARED_SECRET=your_secret_here
 
 **Performance Options:**
 - `--no-flash-attention`: Disable FlashAttention (required for RTX 20xx cards)
-- `--weights-cache SIZE`: Set weights cache size in GiB (default: 4)
+- `--weights-cache SIZE`: Set weights cache size in GiB (default: 50% of RAM)
 - `--cpu-offload`: Enable CPU offloading for large models
 
 **Feature Options:**
@@ -160,7 +160,7 @@ SHARED_SECRET=your_secret_here
 # Start with CPU only
 ./scripts/start-server.sh --cpu-only
 
-# Start with larger weights cache for better performance
+# Start with larger weights cache (override auto-sized default)
 ./scripts/start-server.sh --weights-cache 8
 
 # Start with CPU offloading for large models

--- a/personal server start scripts/scripts/start-server.sh
+++ b/personal server start scripts/scripts/start-server.sh
@@ -69,11 +69,18 @@ BACKGROUND=false
 INTERACTIVE=false
 FORCE_CPU=false
 MODEL_BROWSER=true
-WEIGHTS_CACHE=4
+WEIGHTS_CACHE=""
 SUPERVISED=true
 SHARED_SECRET=""
 CPU_OFFLOAD=false
 DEBUG=false
+
+# Load configuration file so command line arguments can override values
+if [ -f "$CONFIG_FILE" ]; then
+    log "Loading configuration from $CONFIG_FILE"
+    # Source the config file, ignoring comments and empty lines
+    source <(grep -E '^[^#]*=' "$CONFIG_FILE" 2>/dev/null || true)
+fi
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -130,7 +137,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --cpu-only              Force CPU-only mode (no GPU)"
             echo "  --port PORT             Server port (default: 7859)"
             echo "  --no-model-browser      Disable model browsing (enabled by default)"
-            echo "  --weights-cache SIZE    Set weights cache size in GiB (default: 4)"
+            echo "  --weights-cache SIZE    Set weights cache size in GiB (default: 50% of RAM)"
             echo "  --no-supervised         Disable supervised mode (enabled by default)"
             echo "  --shared-secret SECRET  Set shared secret for server security"
             echo "  --cpu-offload           Enable CPU offloading for large models"
@@ -147,11 +154,16 @@ done
 
 log "Starting Draw Things Community Server..."
 
-# Load configuration file if it exists
-if [ -f "$CONFIG_FILE" ]; then
-    log "Loading configuration from $CONFIG_FILE"
-    # Source the config file, ignoring comments and empty lines
-    source <(grep -E '^[^#]*=' "$CONFIG_FILE" 2>/dev/null || true)
+# Determine total memory in GiB if weights cache size wasn't provided
+if [ -z "$WEIGHTS_CACHE" ]; then
+    if command -v free >/dev/null 2>&1; then
+        TOTAL_MEM_GB=$(free -g | awk '/^Mem:/ {print $2}')
+    elif [ -f /proc/meminfo ]; then
+        TOTAL_MEM_GB=$(awk '/MemTotal/ {print int($2/1024/1024)}' /proc/meminfo)
+    else
+        TOTAL_MEM_GB=0
+    fi
+    WEIGHTS_CACHE=$(( TOTAL_MEM_GB / 2 ))
 fi
 
 # Check if models directory exists and has content


### PR DESCRIPTION
## Summary
- auto size `WEIGHTS_CACHE` to half of system RAM
- read `server.conf` before argument parsing to allow CLI override
- document new behaviour in README

## Testing
- `shellcheck 'personal server start scripts/scripts/start-server.sh'`

------
https://chatgpt.com/codex/tasks/task_e_6851c68712b08329b4bef0b33641d6ed